### PR TITLE
Token rotate command hacky rework.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -146,5 +146,6 @@ linters:
     - wsl
     - gosec
     - gocritic
+    - goerr113
 
   fast: false

--- a/README.md
+++ b/README.md
@@ -122,18 +122,28 @@ Custom build parameters or build comments are not supported yet.
 Usage:
 
 ```
-token rotate <userID> <old_token_name> <new_token_name>`
+token rotate <userID> <old_token_name> [<new_token_name>]`
 ```
 
 Example:
 
 ```
-$tc-cli -c configuration.example.yaml token rotate furiousassault token_3 token_2
-Token with name 'token_3' has been rotated successfully.
+$tc-cli -c configuration.example.yaml token rotate furiousassault token_0
+Token with name 'token_0' has been rotated successfully. New token name is 'token_0'. Token file path: '/home/furiousassault/workspace/tc-cli/access.token.token_0.new'
+
+$tc-cli token -c configuration.example.yaml rotate furiousassault token_1 token_11
+Token with name 'token_1' has been rotated successfully. New token name is 'token_11'. Token file path: '/home/furiousassault/workspace/tc-cli/access.token.token_11.new'
 ```
 
 Unfortunately, there's no obvious way to get the token name by its value nor to get userID by token, so user has to
-specify his userID, old token name (which is going to be revoked) and new token name.
+specify his userID, and the name of token that is going to be revoked.
+
+User can optionally specify new token name as the last parameter. New token is stored in
+the `token_file_path.<token_new>.new` path specified. `<token_new>` defaults to old token name if `new_token_name` is
+omitted.
+
+This is done to prevent the unwanted override, if the token user wants to rotate is not his current work token, with
+which application is being run.
 
 When the better way to perform such operation will be discovered (in API or by providing more complex token local
 storage), the behavior will change.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	commandToken "github.com/furiousassault/tc-cli/pkg/commands/token"
 	"github.com/furiousassault/tc-cli/pkg/configuration"
 	"github.com/furiousassault/tc-cli/pkg/output"
 
@@ -15,8 +16,6 @@ import (
 	commandList "github.com/furiousassault/tc-cli/pkg/commands/list"
 	commandLog "github.com/furiousassault/tc-cli/pkg/commands/log"
 	commandRun "github.com/furiousassault/tc-cli/pkg/commands/run"
-	commandToken "github.com/furiousassault/tc-cli/pkg/commands/token"
-
 	apiClient "github.com/furiousassault/tc-cli/pkg/teamcity/api"
 )
 
@@ -35,25 +34,25 @@ func main() {
 	if err != nil {
 		_ = cmdRoot.Usage()
 		log.Fatal(err)
+
 	}
 
-	// fmt.Println("configuration", config)
 	httpClient := &http.Client{
 		Timeout: config.API.HTTP.RequestTimeout,
 	}
 
 	api := apiClient.InitAPI(*config, httpClient)
 	if err = api.Ping(); err != nil {
-		log.Fatal("API ping failed: ", err)
+		log.Fatal(err)
 	}
 
 	cmdRoot.AddCommand(
 		commandLog.CreateCommandBuildLog(api.Logs, output.NewStringPrinterStdout()),
-		commandToken.CreateCommandTreeToken(*config, api.Token),
 		commandDescribe.CreateCommandTreeDescribe(api.Builds, output.NewBuildDescriptionWriter(os.Stdout)),
 		commandList.CreateCommandTreeList(api.Projects, api.Builds, output.NewListWriter(os.Stdout)),
 		commandRun.CreateCommandBuildConfigurationRun(api.BuildQueue, output.NewTriggerResultWriter(os.Stdout)),
 		commandArtifact.CreateCommandTreeArtifact(api.Builds, config.ArtifactsDirectoryDefault),
+		commandToken.CreateCommandTreeToken(*config, api),
 	)
 
 	if err := cmdRoot.Execute(); err != nil {

--- a/pkg/commands/token/validator.go
+++ b/pkg/commands/token/validator.go
@@ -5,15 +5,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const CommandTokenArgsNumber = 3
+const (
+	CommandTokenArgsNumberMin = 2
+	CommandTokenArgsNumberMax = 3
+)
 
 func validateTokenArgs(cmd *cobra.Command, args []string) error {
-	if err := cobra.ExactArgs(CommandTokenArgsNumber)(cmd, args); err != nil {
+	if err := cobra.MinimumNArgs(CommandTokenArgsNumberMin)(cmd, args); err != nil {
 		return errors.Wrap(errValidation, err.Error())
 	}
 
-	if args[1] == args[2] {
-		return errors.Wrap(errValidation, "old and new token names must not be equal")
+	if err := cobra.MaximumNArgs(CommandTokenArgsNumberMax)(cmd, args); err != nil {
+		return errors.Wrap(errValidation, err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
Make third parameter in token rotate optional. Got rid of silent rewriting actual token path.